### PR TITLE
カーソル表示してないときにE+S+Cで現在のマップ読み込み直し

### DIFF
--- a/Eclair/Assets/Scripts/MapLoader.cs
+++ b/Eclair/Assets/Scripts/MapLoader.cs
@@ -83,8 +83,11 @@ public class MapLoader : MonoBehaviour
 			if(!InputManager.isGamePad) InputManager.isGamePad = true;//WASDが押されてないのに移動してる => ゲームパッド(の左スティック)を触ってる
 		}
 
-		if (!CameraController.cursorIsLocked && Input.GetKey (KeyCode.E) && Input.GetKey (KeyCode.S) && Input.GetKey (KeyCode.C)) {
-			Reset ();
+		if (Input.GetKey (KeyCode.E) && Input.GetKey (KeyCode.S) && Input.GetKey (KeyCode.C)) {
+			if (CameraController.cursorIsLocked)
+				ReloadScene ();
+			else 
+				Reset ();
 		}
     }
 


### PR DESCRIPTION
カーソル表示してるときにE+S+Cでタイトル画面に戻るようにした