### PR TITLE
スコア調整

### DIFF
--- a/Eclair/Assets/Scenes/Result.unity
+++ b/Eclair/Assets/Scenes/Result.unity
@@ -1913,13 +1913,13 @@ MonoBehaviour:
   beatedEnemy: 0
   launchedBolt: 0
   optiTime: 600
-  timeScoreFactor: 100
+  timeScoreFactor: 30
   enemyScoreFactor: 100
-  boltScoreFactor: 10
-  timeRankThreshold: 2c010000e001000094020000
-  enemyRankThreshold: 280000001e00000014000000
+  boltScoreFactor: -10
+  timeRankThreshold: e001000058020000d0020000
+  enemyRankThreshold: 1e000000140000000a000000
   boltRankThreshold: 1e0000003c0000005a000000
-  totalRankThreshold: d0070000b80b0000a00f0000
+  totalRankThreshold: a00f0000d0070000e8030000
   canvas: {fileID: 1251208032}
   timeText: {fileID: 294952863}
   timeRank: {fileID: 832444412}
@@ -1933,6 +1933,7 @@ MonoBehaviour:
   totalScore: {fileID: 169288146}
   totalRank: {fileID: 331757662}
   nextButton: {fileID: 776779865}
+  debugMode: 0
 --- !u!111 &1251208038
 Animation:
   m_ObjectHideFlags: 0

--- a/Eclair/Assets/Scripts/AnimationQueue_Number.cs
+++ b/Eclair/Assets/Scripts/AnimationQueue_Number.cs
@@ -27,7 +27,7 @@ public class AnimationQueue_Number : AnimationQueueBase {
 			currentNumber += step;
 			setText (currentNumber);
 		} else if (currentNumber > numberAbs) {
-			setText (number);
+			setText (numberAbs);
 		}
 	}
 

--- a/Eclair/Assets/Scripts/ResultManager.cs
+++ b/Eclair/Assets/Scripts/ResultManager.cs
@@ -71,6 +71,8 @@ public class ResultManager : MonoBehaviour {
 	public AnimationQueue_Rank totalRank;
 	public Button nextButton;
 
+	public bool debugMode;
+
 
 	private float time = 0;
 	private int cursor = 0;
@@ -101,7 +103,10 @@ public class ResultManager : MonoBehaviour {
 	// Use this for initialization
 	void Start () {
         //CameraController.cursorIsLocked = false;
-        setResult((int)ScoreCounter.TimeSinceStarted, ScoreCounter.BeatedEnemyCount, ScoreCounter.LaunchedBoltCount);
+		if (debugMode)
+			setResult(700,50,30);
+		else
+			setResult ((int)ScoreCounter.TimeSinceStarted, ScoreCounter.BeatedEnemyCount, ScoreCounter.LaunchedBoltCount);
 	}
 	
 	// Update is called once per frame


### PR DESCRIPTION
時間は1秒につき30点加点
雑魚敵一体倒すと100点
ボルトを一本打つと-10点
他にも色々閾値を調整したよ